### PR TITLE
contact redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :jekyll_plugins do
   gem "jekyll-autoprefixer"
   gem "jekyll-assets", "~> 3.0"
   gem "jekyll-include-cache"
+  gem 'jekyll-redirect-from'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 # these will not be included in build
 exclude:

--- a/pages/home.html
+++ b/pages/home.html
@@ -2,6 +2,8 @@
 permalink: /
 layout: wide
 title: Home
+redirect_from:
+  - /contact/
 ---
 
 <!-- BANNER -->


### PR DESCRIPTION
## Description

Adds a simple redirect from /contact to the homepage.  The Contact page does not exist yet, but we wanted to use it for some offline use cases.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and have no open issues
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or syntax errors
- [x] I have verified Draft on actual mobile devices, especially Safari-based
