### PR TITLE
allow fellow page indexing in search engines

### DIFF
--- a/pages/fellows.html
+++ b/pages/fellows.html
@@ -2,8 +2,6 @@
 layout: default
 title: Fellows
 permalink: /fellows/
-noindex: true
-sitemap: false
 pagination:
   enabled: true
   collection: fellows


### PR DESCRIPTION
Remove noindex from fellows page to allow it to be searchable in search engines.
