### PR TITLE
set blog blurb text color to black

### DIFF
--- a/_assets/css/pages/_blog.scss
+++ b/_assets/css/pages/_blog.scss
@@ -99,6 +99,10 @@
 .blog-card{
     a {
         text-decoration: none;
+
+    }
+    .usa-card__body{
+      @include u-text("black");
     }
    
 }

--- a/_includes/blog-list.html
+++ b/_includes/blog-list.html
@@ -30,7 +30,7 @@
               {% endfor %}
             </div>
             <div class="usa-card__body">
-              <p>
+              <p class="blog-summary">
                 {{blog.summary}}
               </p>
               <p>


### PR DESCRIPTION
Set blurb text color to black

## Checklist

- [ ] My code follows the existing style, code structure, and naming taxonomy
- [ ] I have performed a self-review of my own code and have no open issues
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or syntax errors
- [ ] I have verified Draft on actual mobile devices, especially Safari-based
